### PR TITLE
Enable Dependabot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,6 +5,6 @@
 
 # The below files have no CODEOWNERS to allow for dependabot automation
 
-.changeset/*.md
+.changeset/dependabot-*.md
 package-lock.json
 **/package.json

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: daily
+    # Limit of 1 PR to avoid rebase being blocked as we are modifying the PRs
+    open-pull-requests-limit: 1
+    labels:
+      - dependencies
+      - npm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       NPM_VERSION: '8.4.1'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Node Version ${{ matrix.node_version }}
         uses: actions/setup-node@v3

--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -1,0 +1,91 @@
+name: Create Dependabot Changeset
+on:
+  pull_request_target:
+    paths:
+      - 'packages/*/package.json'
+      - 'yarn.lock'
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  create_changeset:
+    runs-on: ubuntu-latest
+    if: >
+      ${{
+        github.event.pull_request.user.login == 'dependabot[bot]'
+        && github.repository == 'JP-Dhabolt/gwyddion-npm'
+        && startsWith(github.event.pull_request.head.ref, 'dependabot/')
+      }}
+    steps:
+      # Checking out the main branch for access to the trusted script
+      - uses: actions/checkout@v3
+        with:
+          path: 'mainBranch'
+
+      # Checking out the PR branch to determine changesets and push them
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+          ref: ${{ github.head_ref }}
+          path: 'prBranch'
+
+      # Using dependabot metadata to make decisions regarding changesets and approvals
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1.3.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Git
+        run: |
+          git config --global user.email github-actions@github.com
+          git config --global user.name 'Github Actions'
+
+      - name: Generate Changeset
+        id: gen_changeset
+        uses: actions/github-script@v6
+        env:
+          DEPENDENCY_TYPE: ${{ steps.metadata.outputs.dependency-type }}
+        with:
+          result-encoding: string
+          script: |
+            const { promises: fs } = require('fs');
+            const { handleChangesets } = require('./mainBranch/scripts/changesetCreator');
+            return await handleChangesets({ context, exec, fs });
+
+      - name: Enable auto-merge for Dependabot PRs
+        if: >
+          ${{
+            (
+              steps.metadata.outputs.update-type == 'version-update:semver-patch'
+              || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+            )
+            &&
+            (
+              steps.gen_changeset.outputs.result == 'CHANGES'
+              || steps.gen_changeset.outputs.result == 'NO_CHANGES'
+            )
+          }}
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve PR
+        if: >
+          ${{
+            (
+              steps.metadata.outputs.update-type == 'version-update:semver-patch'
+              || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+            )
+            &&
+            (
+              steps.gen_changeset.outputs.result == 'CHANGES'
+              || steps.gen_changeset.outputs.result == 'NO_CHANGES'
+            )
+          }}
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       NPM_VERSION: '8.4.1'
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup Node 14
         uses: actions/setup-node@v3

--- a/internal/tests/jest.config.js
+++ b/internal/tests/jest.config.js
@@ -1,0 +1,12 @@
+// eslint-disable-next-line
+const base = require('@internal/config/config/jest.config');
+
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  ...base,
+  globals: {
+    'ts-jest': {
+      tsconfig: 'tsconfig.json',
+    },
+  },
+};

--- a/internal/tests/package.json
+++ b/internal/tests/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "@internal/tests",
+  "version": "0.1.0",
+  "description": "Tests for internal functionality",
+  "private": true,
+  "files": [],
+  "scripts": {
+    "test": "jest --coverage",
+    "watch": "jest --watch"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/JP-Dhabolt/gwyddion-npm.git",
+    "directory": "internal/tests"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/JP-Dhabolt/gwyddion-npm/issues"
+  },
+  "homepage": "https://github.com/JP-Dhabolt/gwyddion-npm#readme",
+  "dependencies": {}
+}

--- a/internal/tests/tests/changesetCreator.spec.ts
+++ b/internal/tests/tests/changesetCreator.spec.ts
@@ -1,0 +1,104 @@
+import { handleChangesets } from '../../../scripts/changesetCreator';
+
+const mockChdir = jest.fn();
+const mockExec = {
+  getExecOutput: jest.fn(async () => '.changeset/dependabot-foo.md'),
+  exec: jest.fn(),
+};
+const mockFs = {
+  readFile: jest.fn(),
+  writeFile: jest.fn(),
+};
+
+describe('changesetCreator', () => {
+  const ORIGINAL_ENV = process.env;
+  const ORIGINAL_CHDIR = process.chdir;
+  const input = {
+    context: {
+      payload: {
+        pull_request: {
+          head: {
+            sha: 'foo',
+          },
+          title: 'bump version',
+        },
+      },
+    },
+    exec: mockExec,
+    fs: mockFs,
+  };
+
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    process.env.DEPENDENCY_TYPE = 'direct:production';
+    mockChdir.mockClear();
+    mockExec.exec.mockClear();
+    mockExec.getExecOutput.mockClear();
+    mockFs.readFile.mockClear();
+    mockFs.writeFile.mockClear();
+    process.chdir = mockChdir;
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL_ENV;
+    process.chdir = ORIGINAL_CHDIR;
+  });
+
+  it('should return "NO_CHANGES" if not prod dependency', async () => {
+    process.env.DEPENDENCY_TYPE = 'direct:dev';
+    const result = await handleChangesets(input);
+    expect(result).toEqual('NO_CHANGES');
+  });
+
+  it('should change the working directory', async () => {
+    await handleChangesets(input);
+    expect(mockChdir).toHaveBeenCalledTimes(1);
+    expect(mockChdir).toHaveBeenCalledWith('./prBranch');
+  });
+
+  it('should return "SKIPPED" if changeset already exists', async () => {
+    const result = await handleChangesets(input);
+    expect(result).toEqual('SKIPPED');
+  });
+
+  it('should return "NO_CHANGES" if no modified packages', async () => {
+    mockExec.getExecOutput.mockImplementationOnce(async () => 'not-package');
+    const result = await handleChangesets(input);
+    expect(result).toEqual('NO_CHANGES');
+  });
+
+  it('should return "NO_CHANGES" if root package.json changed only', async () => {
+    mockExec.getExecOutput.mockImplementationOnce(async () => 'package.json');
+    const result = await handleChangesets(input);
+    expect(result).toEqual('NO_CHANGES');
+  });
+
+  it('should return "NO_CHANGES" if changed package is private', async () => {
+    mockExec.getExecOutput.mockImplementationOnce(async () => 'internal/foo/package.json');
+    mockFs.readFile.mockImplementationOnce(async () => JSON.stringify({ private: true }));
+    const result = await handleChangesets(input);
+    expect(result).toEqual('NO_CHANGES');
+  });
+
+  it('should write a changeset it changed package is public', async () => {
+    mockExec.getExecOutput.mockImplementationOnce(async () => 'packages/foo/package.json');
+    mockFs.readFile.mockImplementationOnce(async () => JSON.stringify({ name: '@scope/foo' }));
+    const result = await handleChangesets(input);
+    expect(result).toEqual('CHANGES');
+    expect(mockFs.writeFile).toHaveBeenCalledTimes(1);
+    expect(mockFs.writeFile).toHaveBeenCalledWith(
+      '.changeset/dependabot-foo.md',
+      '---\n@scope/foo: patch\n---\n\nbump version\n',
+    );
+  });
+
+  it('should should commit and push after changeset is created', async () => {
+    mockExec.getExecOutput.mockImplementationOnce(async () => 'packages/foo/package.json');
+    mockFs.readFile.mockImplementationOnce(async () => JSON.stringify({ name: '@scope/foo' }));
+    await handleChangesets(input);
+    expect(mockExec.exec).toHaveBeenCalledTimes(3);
+    expect(mockExec.exec).toHaveBeenCalledWith('git', ['add', '.changeset/dependabot-foo.md']);
+    expect(mockExec.exec).toHaveBeenCalledWith('git', ['commit', '-C', 'HEAD', '--amend', '--no-edit']);
+    expect(mockExec.exec).toHaveBeenCalledWith('git', ['push', '--force']);
+  });
+});

--- a/internal/tests/tsconfig.json
+++ b/internal/tests/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "extends": "@internal/config/config/node-tsconfig.json",
+  "include": [
+    "./**/*.ts",
+    "../../scripts/*.js"
+  ],
+  "exclude": [
+    "internal/tests/dist",
+    "packages/**"
+  ],
+  "compilerOptions": {
+    "outDir": "internal/tests/dist",
+    "rootDir": "../../"
+  },
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,11 @@
       }
     },
     "internal/create": {
+      "name": "@internal/create",
+      "version": "0.1.0",
+      "license": "ISC"
+    },
+    "internal/tests": {
       "version": "0.1.0",
       "license": "ISC"
     },
@@ -897,6 +902,10 @@
     },
     "node_modules/@internal/create": {
       "resolved": "internal/create",
+      "link": true
+    },
+    "node_modules/@internal/tests": {
+      "resolved": "internal/tests",
       "link": true
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -9660,7 +9669,7 @@
     },
     "packages/is-even": {
       "name": "@gwyddion/is-even",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "ISC",
       "devDependencies": {}
     },
@@ -10381,6 +10390,9 @@
     },
     "@internal/create": {
       "version": "file:internal/create"
+    },
+    "@internal/tests": {
+      "version": "file:internal/tests"
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",

--- a/scripts/changesetCreator.js
+++ b/scripts/changesetCreator.js
@@ -1,0 +1,72 @@
+/* eslint-disable no-console */
+const SKIPPED = 'SKIPPED';
+const NO_CHANGES = 'NO_CHANGES';
+const CHANGES = 'CHANGES';
+const PR_BRANCH = 'prBranch';
+const PROD_DEPENDENCY = 'direct:production';
+const CHANGESET_DIR = '.changeset';
+
+async function getPackageFilesWithChangedDependencies(diffFiles, fs) {
+  const packageFiles = diffFiles.filter(f => f !== 'package.json').filter(f => f.includes('package.json'));
+  const changedPackages = [];
+
+  for (const file of packageFiles) {
+    const prPackage = JSON.parse(await fs.readFile(file, 'utf8'));
+
+    if (!prPackage.private) {
+      changedPackages.push(prPackage.name);
+    }
+  }
+
+  return changedPackages;
+}
+
+async function createChangeset(fs, packages, context, changesetFile) {
+  const { title: message } = context.payload.pull_request;
+  const packageFrontMatter = packages.map(p => `${p}: patch`).join('\n');
+  const fileContents = `---\n${packageFrontMatter}\n---\n\n${message}\n`;
+  await fs.writeFile(changesetFile, fileContents);
+}
+
+async function getChangedFiles(exec) {
+  const diffOutput = await exec.getExecOutput('git diff --name-only HEAD~1');
+  const diffFiles = diffOutput.split('\n');
+  return diffFiles;
+}
+
+async function commitAndPushChanges(exec, changesetFile) {
+  await exec.exec('git', ['add', changesetFile]);
+  await exec.exec('git', ['commit', '-C', 'HEAD', '--amend', '--no-edit']);
+  await exec.exec('git', ['push', '--force']);
+}
+
+async function handleChangesets({ context, exec, fs }) {
+  const { DEPENDENCY_TYPE } = process.env;
+
+  if (DEPENDENCY_TYPE !== PROD_DEPENDENCY) {
+    console.log('Non-production dependencies, skipping changeset creation');
+    return NO_CHANGES;
+  }
+
+  process.chdir(`./${PR_BRANCH}`);
+
+  const diffFiles = await getChangedFiles(exec);
+  if (diffFiles.find(f => f.startsWith(CHANGESET_DIR))) {
+    console.log('Changeset already created, skipping');
+    return SKIPPED;
+  }
+
+  const changedPackages = await getPackageFilesWithChangedDependencies(diffFiles, fs);
+  if (changedPackages.length === 0) {
+    console.log('No packages with modified dependencies');
+    return NO_CHANGES;
+  }
+
+  const { sha } = context.payload.pull_request.head;
+  const changesetFile = `${CHANGESET_DIR}/dependabot-${sha}.md`;
+  await createChangeset(fs, changedPackages, context, changesetFile);
+  await commitAndPushChanges(exec, changesetFile);
+  return CHANGES;
+}
+
+module.exports = { handleChangesets };


### PR DESCRIPTION
Also add `pull_request_target` workflow to automate dependabot changeset creation for production dependency changes, and automate approvals for minor and semver bumps.