### PR TITLE
Use privileged token for changeset prs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -34,5 +34,5 @@ jobs:
         with:
           publish: make publish
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GWYDDION_AUTOMATION_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Using built in `GITHUB_TOKEN` blocks CI workflow from triggering.