### PR TITLE
Fix paths for dependabot workflow

### DIFF
--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -2,8 +2,9 @@ name: Create Dependabot Changeset
 on:
   pull_request_target:
     paths:
+      - 'package.json'
       - 'packages/*/package.json'
-      - 'yarn.lock'
+      - 'package-lock.json'
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
Missing `package.json` and had `yarn.lock` instead of `package-lock.json`