### PR TITLE
Update GITHUB_TOKEN for PR approval

### DIFF
--- a/.github/workflows/dependabot-changeset.yml
+++ b/.github/workflows/dependabot-changeset.yml
@@ -83,4 +83,4 @@ jobs:
         run: gh pr review --approve "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GWYDDION_AUTOMATION_TOKEN }}


### PR DESCRIPTION
Without this, CI workflow does not kick off after merge.