### PR TITLE
Add missing template files

### DIFF
--- a/.changeset/twenty-bears-study.md
+++ b/.changeset/twenty-bears-study.md
@@ -1,0 +1,5 @@
+---
+'@gwyddion/create': patch
+---
+
+Resolve issue where not all template files are bundled in published package.

--- a/packages/create/.npmignore
+++ b/packages/create/.npmignore
@@ -4,7 +4,7 @@
 # Unignore files we specifically want
 !dist/**/*.js
 !dist/**/*.d.ts
-!templates
+!templates/**/*
 !CHANGELOG.md
 
 # Re-ignore test files


### PR DESCRIPTION
.npmignore glob to re-add template files was not hungry enough, resulting in template files missing from published NPM package.