### PR TITLE
Bugfix: Bundle map files in dist

### DIFF
--- a/.changeset/tidy-olives-work.md
+++ b/.changeset/tidy-olives-work.md
@@ -1,0 +1,8 @@
+---
+'@gwyddion/create': patch
+'@gwyddion/is-even': patch
+'@gwyddion/is-odd': patch
+'@gwyddion/react-components': patch
+---
+
+Bundle map files in published distributions

--- a/packages/create/.npmignore
+++ b/packages/create/.npmignore
@@ -6,6 +6,7 @@
 !dist/**/*
 !templates/**/*
 !CHANGELOG.md
+!dist/**/*.map
 
 # Re-ignore test files
 dist/**/*.spec.js

--- a/packages/create/templates/default/.npmignore.template
+++ b/packages/create/templates/default/.npmignore.template
@@ -5,6 +5,7 @@
 !dist/**/*.js
 !dist/**/*.d.ts
 !CHANGELOG.md
+!dist/**/*.map
 
 # Re-ignore test files
 dist/**/*.spec.js

--- a/packages/create/templates/react/.npmignore.template
+++ b/packages/create/templates/react/.npmignore.template
@@ -5,6 +5,7 @@
 !dist/**/*.js
 !dist/**/*.d.ts
 !CHANGELOG.md
+!dist/**/*.map
 
 # Re-ignore test files
 dist/**/*.spec.js

--- a/packages/is-even/.npmignore
+++ b/packages/is-even/.npmignore
@@ -5,6 +5,7 @@
 !dist/**/*.js
 !dist/**/*.d.ts
 !CHANGELOG.md
+!dist/**/*.map
 
 # Re-ignore test files
 dist/**/*.spec.js

--- a/packages/is-odd/.npmignore
+++ b/packages/is-odd/.npmignore
@@ -5,6 +5,7 @@
 !dist/**/*.js
 !dist/**/*.d.ts
 !CHANGELOG.md
+!dist/**/*.map
 
 # Re-ignore test files
 dist/**/*.spec.js

--- a/packages/react-components/.npmignore
+++ b/packages/react-components/.npmignore
@@ -5,6 +5,7 @@
 !dist/**/*.js
 !dist/**/*.d.ts
 !CHANGELOG.md
+!dist/**/*.map
 
 # Re-ignore test files
 dist/**/*.spec.js


### PR DESCRIPTION
Warnings when using the `react-components` library due to missing map files.